### PR TITLE
fix: アプリ起動時の二重画面表示を修正 #10

### DIFF
--- a/src/SourceFlow.UI/App.xaml
+++ b/src/SourceFlow.UI/App.xaml
@@ -1,8 +1,7 @@
 ﻿<Application x:Class="SourceFlow.UI.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:SourceFlow.UI"
-             StartupUri="MainWindow.xaml">
+             xmlns:local="clr-namespace:SourceFlow.UI">
     <Application.Resources>
          
     </Application.Resources>


### PR DESCRIPTION
## 概要
アプリケーション起動時に2つの画面が表示される問題を修正しました。App.xamlのStartupUriとOnStartupメソッドでの手動作成が競合していたため、StartupUriを削除して手動作成のみに統一しました。

## 変更点

### 🐛 問題解決
- App.xamlから`StartupUri="MainWindow.xaml"`を削除
- WPFアプリケーションの起動フローを手動作成のみに統一
- 起動時に表示される画面数を2つから1つに修正

### 🔧 技術的修正内容
- **二重起動の回避**: StartupUriによる自動起動を無効化
- **DI統合の維持**: OnStartupでの依存性注入は既存通り正常動作
- **最小限の変更**: App.xamlの1行削除のみで問題解決

## テスト

### ✅ 動作確認
- [x] dotnet buildでエラー・警告が0件であることを確認
- [x] アプリケーション起動フローが正常動作することを確認
- [x] DIコンテナからのMainWindow・ViewModel取得が正常動作することを確認

### ✅ 受け入れ条件達成
- [x] 起動時に1画面のみ表示される
- [x] 全ての機能が正常動作する
- [x] DIコンテナからの依存性注入が正常機能する  
- [x] 起動時間に悪影響がない

### 🔍 根本原因と解決策
**根本原因**: WPFアプリケーションでStartupUriによる自動起動とOnStartupメソッドでの手動作成が同時実行され、MainWindowが2つ作成されていた

**解決策**: StartupUriを削除し、OnStartupでの手動作成（DI統合済み）のみに統一することで、1つのMainWindowのみが作成されるように修正

## 影響範囲
- **変更ファイル**: `src/SourceFlow.UI/App.xaml` (1行削除)
- **影響範囲**: WPFアプリケーション起動フロー
- **後方互換性**: 既存機能への影響なし

fixes #10